### PR TITLE
fix: remove same-path 200 redirects causing infinite 308 loops

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,8 +2,4 @@
 /acat-assessment-tool.html  /assess.html  301
 /acat-assessment  /assess.html  301
 /acat  /assess.html  301
-/research  /research.html  200
-/about  /about.html  200
-/methods  /methods.html  200
-/observatory  /observatory.html  200
-/methodology  /methodology.html  200
+/phase1  /assess  301


### PR DESCRIPTION
## Summary

Fixes the live production emergency: `/about`, `/research`, `/methods`, `/methodology`, and `/observatory` are unreachable due to infinite 308 redirect loops.

**Root cause:** Cloudflare Pages automatically strips `.html` extensions for files in `public/`. The same-path `200` rewrite rules in `_redirects` (e.g., `/research → /research.html 200`) collide with this behavior, creating the loops.

## Changes

- **Remove** 5 problematic same-path `200` rules
- **Add** `/phase1 → /assess 301` redirect (operations/PARTICIPATE.md sends here; page never existed)

## Verification

- `/governance` and `/empirica` already work correctly with zero redirect rules
- This confirms the same-path rules are unnecessary and harmful

## Zone Label

- [x] Zone 1 (Claude proposes)
- [x] Zone 2 (Carly ratifies)  
- [ ] Zone 3 (Deploy)

**Ready for merge once verified against production.**

---

This is Phase 1 of the website governance alignment plan (see `.claude/plans/toasty-wibbling-bee.md`).